### PR TITLE
Implement 'candidate_func' parameter to filter down the pool of candidates for selection

### DIFF
--- a/python/packages/autogen-agentchat/tests/test_group_chat_endpoint.py
+++ b/python/packages/autogen-agentchat/tests/test_group_chat_endpoint.py
@@ -6,6 +6,7 @@ from autogen_agentchat.teams import SelectorGroupChat
 from autogen_agentchat.ui import Console
 from autogen_core.models import ChatCompletionClient
 from autogen_ext.models.openai import OpenAIChatCompletionClient
+from autogen_agentchat.base import TaskResult
 
 
 async def _test_selector_group_chat(model_client: ChatCompletionClient) -> None:
@@ -27,6 +28,52 @@ async def _test_selector_group_chat(model_client: ChatCompletionClient) -> None:
     await Console(team.run_stream(task="Draft a short email about organizing a holiday party for new year."))
 
 
+async def _test_selector_group_chat_with_candidate_func(model_client: ChatCompletionClient) -> None:
+
+    filtered_participants = ['developer', 'tester']
+
+    def dummy_candidate_func(thread, participants):
+        # Dummy candidate function that will return
+        # only return developer and reviewer
+        return filtered_participants
+
+    developer = AssistantAgent(
+        "developer",
+        description="Writes and implements code based on requirements.",
+        model_client=model_client,
+        system_message="You are a software developer working on a new feature."
+    )
+
+    tester = AssistantAgent(
+        "tester",
+        description="Writes and executes test cases to validate the implementation.",
+        model_client=model_client,
+        system_message="You are a software tester ensuring the feature works correctly."
+    )
+
+    project_manager = AssistantAgent(
+        "project_manager",
+        description="Oversees the project and ensures alignment with the broader goals.",
+        model_client=model_client,
+        system_message="You are a project manager ensuring the team meets the project goals."
+    )
+
+    team = SelectorGroupChat(
+        participants=[developer, tester, project_manager],
+        model_client=model_client,
+        max_turns=3,
+        candidate_func=dummy_candidate_func,
+    )
+
+    task = "Create a detailed implementation plan for adding dark mode in a React app and review it for feasibility and improvements."
+
+    async for message in team.run_stream(task=task):
+        if not isinstance(message, TaskResult):
+            if message.source == 'user':  # ignore the first 'user' message
+                continue
+            assert message.source in filtered_participants, "Candidate function didn't filter the participants"
+
+
 @pytest.mark.asyncio
 async def test_selector_group_chat_gemini() -> None:
     try:
@@ -39,6 +86,7 @@ async def test_selector_group_chat_gemini() -> None:
         api_key=api_key,
     )
     await _test_selector_group_chat(model_client)
+    await _test_selector_group_chat_with_candidate_func(model_client)
 
 
 @pytest.mark.asyncio
@@ -53,3 +101,4 @@ async def test_selector_group_chat_openai() -> None:
         api_key=api_key,
     )
     await _test_selector_group_chat(model_client)
+    await _test_selector_group_chat_with_candidate_func(model_client)

--- a/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/selector-group-chat.ipynb
+++ b/python/packages/autogen-core/docs/src/user-guide/agentchat-user-guide/selector-group-chat.ipynb
@@ -20,6 +20,7 @@
     "- Prevention of consecutive turns by the same speaker (optional)\n",
     "- Customizable selection prompting\n",
     "- Customizable selection function to override the default model-based selection\n",
+    "- Customizable candidate function to narrow-down the set of agents for selection using model\n",
     "\n",
     "```{note}\n",
     "{py:class}`~autogen_agentchat.teams.SelectorGroupChat` is a high-level API. For more control and customization, refer to the [Group Chat Pattern](../core-user-guide/design-patterns/group-chat.ipynb) in the Core API documentation to implement your own group chat logic.\n",
@@ -56,7 +57,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from typing import Sequence\n",
+    "from typing import Sequence, List\n",
     "\n",
     "from autogen_agentchat.agents import AssistantAgent, UserProxyAgent\n",
     "from autogen_agentchat.conditions import MaxMessageTermination, TextMentionTermination\n",
@@ -545,6 +546,134 @@
     "checking the last message and returning the agent if it is a\n",
     "{py:class}`~autogen_agentchat.messages.ToolCallSummaryMessage`.\n",
     "```"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Custom Candidate Function"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "One more possible requirement might be to automatically select the next speaker from a filtered list of agents.\n",
+    "For this, we can set `candidate_func` argument with a custom candidate function to filter down the list of potential agents for speaker selection for each turn of groupchat.\n",
+    "\n",
+    "This allow us to restrict speaker selection to a specific set of agents after a given agent.\n",
+    "\n",
+    "\n",
+    "```{note}\n",
+    "The `candidate_func` is only valid if `selector_func` is not set.\n",
+    "Returning `None` or an empty list `[]` from the custom candidate function will raise a `ValueError`.\n",
+    "```"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "---------- user ----------\n",
+      "Who was the Miami Heat player with the highest points in the 2006-2007 season, and what was the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons?\n",
+      "---------- PlanningAgent ----------\n",
+      "To address this request, we need to break down the task into several subtasks:\n",
+      "\n",
+      "1. Determine which Miami Heat player had the highest points in the 2006-2007 season.\n",
+      "2. Find the player's total rebounds in the 2007-2008 season.\n",
+      "3. Find the player's total rebounds in the 2008-2009 season.\n",
+      "4. Calculate the percentage change in total rebounds between the 2007-2008 and 2008-2009 seasons.\n",
+      "\n",
+      "Let's start by assigning these tasks:\n",
+      "\n",
+      "1. WebSearchAgent: Find which Miami Heat player had the highest points in the 2006-2007 NBA season.\n",
+      "2. WebSearchAgent: Find the total rebounds for this player in the 2007-2008 NBA season.\n",
+      "3. WebSearchAgent: Find the total rebounds for this player in the 2008-2009 NBA season.\n",
+      "---------- WebSearchAgent ----------\n",
+      "[FunctionCall(id='call_wOOOvE3q72lY34x3cocGN2Li', arguments='{\"query\":\"Miami Heat highest points player 2006-2007 NBA season\"}', name='search_web_tool')]\n",
+      "---------- WebSearchAgent ----------\n",
+      "[FunctionExecutionResult(content='Here are the total points scored by Miami Heat players in the 2006-2007 season:\\n        Udonis Haslem: 844 points\\n        Dwayne Wade: 1397 points\\n        James Posey: 550 points\\n        ...\\n        ', name='search_web_tool', call_id='call_wOOOvE3q72lY34x3cocGN2Li', is_error=False)]\n",
+      "---------- WebSearchAgent ----------\n",
+      "Here are the total points scored by Miami Heat players in the 2006-2007 season:\n",
+      "        Udonis Haslem: 844 points\n",
+      "        Dwayne Wade: 1397 points\n",
+      "        James Posey: 550 points\n",
+      "        ...\n",
+      "        \n",
+      "---------- WebSearchAgent ----------\n",
+      "[FunctionCall(id='call_oz1OrW5yPaBnKK3g97ZckT0G', arguments='{\"query\": \"Dwyane Wade total rebounds 2007-2008 season\"}', name='search_web_tool'), FunctionCall(id='call_U10xaY1lgLFyArUHl1yAd6wu', arguments='{\"query\": \"Dwyane Wade total rebounds 2008-2009 season\"}', name='search_web_tool')]\n",
+      "---------- WebSearchAgent ----------\n",
+      "[FunctionExecutionResult(content='The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214.', name='search_web_tool', call_id='call_oz1OrW5yPaBnKK3g97ZckT0G', is_error=False), FunctionExecutionResult(content='The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398.', name='search_web_tool', call_id='call_U10xaY1lgLFyArUHl1yAd6wu', is_error=False)]\n",
+      "---------- WebSearchAgent ----------\n",
+      "The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214.\n",
+      "The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398.\n",
+      "---------- DataAnalystAgent ----------\n",
+      "[FunctionCall(id='call_RbMhh60TW8qJzdWqVrEaZJu2', arguments='{\"start\":214,\"end\":398}', name='percentage_change_tool')]\n",
+      "---------- DataAnalystAgent ----------\n",
+      "[FunctionExecutionResult(content='85.98130841121495', name='percentage_change_tool', call_id='call_RbMhh60TW8qJzdWqVrEaZJu2', is_error=False)]\n",
+      "---------- DataAnalystAgent ----------\n",
+      "85.98130841121495\n",
+      "---------- PlanningAgent ----------\n",
+      "To summarize:\n",
+      "\n",
+      "1. Dwayne Wade was the Miami Heat player with the highest points in the 2006-2007 season, scoring 1397 points.\n",
+      "2. In the 2007-2008 season, Dwayne Wade had a total of 214 rebounds.\n",
+      "3. In the 2008-2009 season, Dwayne Wade had a total of 398 rebounds.\n",
+      "4. The percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons was approximately 85.98%.\n",
+      "\n",
+      "TERMINATE\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "TaskResult(messages=[TextMessage(source='user', models_usage=None, metadata={}, content='Who was the Miami Heat player with the highest points in the 2006-2007 season, and what was the percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons?', type='TextMessage'), TextMessage(source='PlanningAgent', models_usage=RequestUsage(prompt_tokens=161, completion_tokens=180), metadata={}, content=\"To address this request, we need to break down the task into several subtasks:\\n\\n1. Determine which Miami Heat player had the highest points in the 2006-2007 season.\\n2. Find the player's total rebounds in the 2007-2008 season.\\n3. Find the player's total rebounds in the 2008-2009 season.\\n4. Calculate the percentage change in total rebounds between the 2007-2008 and 2008-2009 seasons.\\n\\nLet's start by assigning these tasks:\\n\\n1. WebSearchAgent: Find which Miami Heat player had the highest points in the 2006-2007 NBA season.\\n2. WebSearchAgent: Find the total rebounds for this player in the 2007-2008 NBA season.\\n3. WebSearchAgent: Find the total rebounds for this player in the 2008-2009 NBA season.\", type='TextMessage'), ToolCallRequestEvent(source='WebSearchAgent', models_usage=RequestUsage(prompt_tokens=328, completion_tokens=28), metadata={}, content=[FunctionCall(id='call_wOOOvE3q72lY34x3cocGN2Li', arguments='{\"query\":\"Miami Heat highest points player 2006-2007 NBA season\"}', name='search_web_tool')], type='ToolCallRequestEvent'), ToolCallExecutionEvent(source='WebSearchAgent', models_usage=None, metadata={}, content=[FunctionExecutionResult(content='Here are the total points scored by Miami Heat players in the 2006-2007 season:\\n        Udonis Haslem: 844 points\\n        Dwayne Wade: 1397 points\\n        James Posey: 550 points\\n        ...\\n        ', name='search_web_tool', call_id='call_wOOOvE3q72lY34x3cocGN2Li', is_error=False)], type='ToolCallExecutionEvent'), ToolCallSummaryMessage(source='WebSearchAgent', models_usage=None, metadata={}, content='Here are the total points scored by Miami Heat players in the 2006-2007 season:\\n        Udonis Haslem: 844 points\\n        Dwayne Wade: 1397 points\\n        James Posey: 550 points\\n        ...\\n        ', type='ToolCallSummaryMessage'), ToolCallRequestEvent(source='WebSearchAgent', models_usage=RequestUsage(prompt_tokens=421, completion_tokens=71), metadata={}, content=[FunctionCall(id='call_oz1OrW5yPaBnKK3g97ZckT0G', arguments='{\"query\": \"Dwyane Wade total rebounds 2007-2008 season\"}', name='search_web_tool'), FunctionCall(id='call_U10xaY1lgLFyArUHl1yAd6wu', arguments='{\"query\": \"Dwyane Wade total rebounds 2008-2009 season\"}', name='search_web_tool')], type='ToolCallRequestEvent'), ToolCallExecutionEvent(source='WebSearchAgent', models_usage=None, metadata={}, content=[FunctionExecutionResult(content='The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214.', name='search_web_tool', call_id='call_oz1OrW5yPaBnKK3g97ZckT0G', is_error=False), FunctionExecutionResult(content='The number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398.', name='search_web_tool', call_id='call_U10xaY1lgLFyArUHl1yAd6wu', is_error=False)], type='ToolCallExecutionEvent'), ToolCallSummaryMessage(source='WebSearchAgent', models_usage=None, metadata={}, content='The number of total rebounds for Dwayne Wade in the Miami Heat season 2007-2008 is 214.\\nThe number of total rebounds for Dwayne Wade in the Miami Heat season 2008-2009 is 398.', type='ToolCallSummaryMessage'), ToolCallRequestEvent(source='DataAnalystAgent', models_usage=RequestUsage(prompt_tokens=448, completion_tokens=21), metadata={}, content=[FunctionCall(id='call_RbMhh60TW8qJzdWqVrEaZJu2', arguments='{\"start\":214,\"end\":398}', name='percentage_change_tool')], type='ToolCallRequestEvent'), ToolCallExecutionEvent(source='DataAnalystAgent', models_usage=None, metadata={}, content=[FunctionExecutionResult(content='85.98130841121495', name='percentage_change_tool', call_id='call_RbMhh60TW8qJzdWqVrEaZJu2', is_error=False)], type='ToolCallExecutionEvent'), ToolCallSummaryMessage(source='DataAnalystAgent', models_usage=None, metadata={}, content='85.98130841121495', type='ToolCallSummaryMessage'), TextMessage(source='PlanningAgent', models_usage=RequestUsage(prompt_tokens=480, completion_tokens=115), metadata={}, content='To summarize:\\n\\n1. Dwayne Wade was the Miami Heat player with the highest points in the 2006-2007 season, scoring 1397 points.\\n2. In the 2007-2008 season, Dwayne Wade had a total of 214 rebounds.\\n3. In the 2008-2009 season, Dwayne Wade had a total of 398 rebounds.\\n4. The percentage change in his total rebounds between the 2007-2008 and 2008-2009 seasons was approximately 85.98%.\\n\\nTERMINATE', type='TextMessage')], stop_reason=\"Text 'TERMINATE' mentioned\")"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "def candidate_func(messages: Sequence[AgentEvent | ChatMessage], participants: List[str]) -> str | None:\n",
+    "    # keep planning_agent first one to plan out the tasks\n",
+    "    if messages[-1].source == \"user\":\n",
+    "        return [planning_agent.name]\n",
+    "\n",
+    "    # we can assume that the task is finished once the web_search_agent\n",
+    "    # and data_analyst_agent have have took their turns, thus we send\n",
+    "    # in planning_agent to terminate the chat\n",
+    "    previous_set_of_agents = set(message.source for message in messages)\n",
+    "    if web_search_agent.name in previous_set_of_agents and data_analyst_agent.name in previous_set_of_agents:\n",
+    "        return [planning_agent.name]\n",
+    "\n",
+    "    participants.remove(planning_agent.name)\n",
+    "    return participants  # SelectorGroupChat will select from the remaining two agents.\n",
+    "\n",
+    "# Reset the previous team and run the chat again with the selector function.\n",
+    "await team.reset()\n",
+    "team = SelectorGroupChat(\n",
+    "    [planning_agent, web_search_agent, data_analyst_agent],\n",
+    "    model_client=model_client,\n",
+    "    termination_condition=termination,\n",
+    "    allow_repeated_speaker=True,\n",
+    "    candidate_func=candidate_func,\n",
+    ")\n",
+    "\n",
+    "await Console(team.run_stream(task=task))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can see from the conversation log that the Planning Agent returns to conversation once the Web Search Agent and Data Analyst Agent took their turns."
    ]
   },
   {


### PR DESCRIPTION
## Summary of Changes
- Added 'candidate_func' to 'SelectorGroupChat' to narrow-down the pool of candidate speakers.
- Introduced a test in tests/test_group_chat_endpoint.py to validate its functionality.
- Updated the selector group chat user guide with an example demonstrating 'candidate_func'.

## Why are these changes needed?
- These changes adds a new parameter `candidate_func` to `SelectorGroupChat` that helps user narrow-down the set of agents for speaker selection, allowing users to automatically select next speaker from a smaller pool of agents.

## Related issue number
Closes #5828

## Checks

- [x] I've included any doc changes needed for <https://microsoft.github.io/autogen/>. See <https://github.com/microsoft/autogen/blob/main/CONTRIBUTING.md> to build and test documentation locally.
- [x] I've added tests (if relevant) corresponding to the changes introduced in this PR.
- [x] I've made sure all auto checks have passed.
